### PR TITLE
Preselect active layer for normalization

### DIFF
--- a/svir/normalization_dialog.py
+++ b/svir/normalization_dialog.py
@@ -54,27 +54,22 @@ class NormalizationDialog(QDialog):
         self.ui.setupUi(self)
         self.ok_button = self.ui.buttonBox.button(QDialogButtonBox.Ok)
         self.use_advanced = False
+        active_layer_name = None
         reg = QgsMapLayerRegistry.instance()
-        layer_list = []
-        active_layer = None
-        active_layer_id = None
         if iface.activeLayer():  # it's possible that no layer is active
-            active_layer = iface.activeLayer()
-            active_layer_id = active_layer.id()
-        for idx, layer in enumerate(reg.mapLayers().values()):
-            layer_list.append(layer.name())
-            if layer.id() == active_layer_id:
-                active_layer_index = idx
-        if not layer_list:
+            active_layer_name = iface.activeLayer().name()
+
+        if not reg.count():
             msg = 'No layer available for normalization'
             self.iface.messageBar().pushMessage(
                 tr("Error"),
                 tr(msg),
                 level=QgsMessageBar.CRITICAL)
             return
-        self.ui.layer_cbx.addItems(layer_list)
-        if active_layer:
-            self.ui.layer_cbx.setCurrentIndex(active_layer_index)
+        self.ui.layer_cbx.addItems([l.name() for l in reg.mapLayers().values()])
+        active_layer_index = self.ui.layer_cbx.findText(active_layer_name)
+        self.ui.layer_cbx.setCurrentIndex(active_layer_index)
+
         alg_list = NORMALIZATION_ALGS.keys()
         self.ui.algorithm_cbx.addItems(alg_list)
         if self.ui.algorithm_cbx.currentText() in ['RANK', 'QUADRATIC']:

--- a/svir/svir.py
+++ b/svir/svir.py
@@ -329,8 +329,8 @@ class Svir:
         algorithm
         """
         dlg = NormalizationDialog(self.iface)
+        reg = QgsMapLayerRegistry.instance()
         if dlg.exec_():
-            reg = QgsMapLayerRegistry.instance()
             layer = reg.mapLayers().values()[
                 dlg.ui.layer_cbx.currentIndex()]
             attribute_name = dlg.ui.attrib_cbx.currentText()


### PR DESCRIPTION
When the user opens the dialog to perform data transformation, in case one of the layers is active, such layer will be pre-selected in the combobox.
This pull request also rearranges some code, fixing the fact that some of the logic belonging to the data transformation dialog was handled outside the dialog itself.
