### PR TITLE
Remove loss product from zonal statistics (only keep points count, loss sum and avg)

### DIFF
--- a/svir/svir.py
+++ b/svir/svir.py
@@ -540,13 +540,10 @@ class Svir:
             sum_field.setTypeName(DOUBLE_FIELD_TYPE_NAME)
             avg_field = QgsField("avg", QVariant.Double)
             avg_field.setTypeName(DOUBLE_FIELD_TYPE_NAME)
-            prod_field = QgsField("prod", QVariant.Double)
-            prod_field.setTypeName(DOUBLE_FIELD_TYPE_NAME)
             pr.addAttributes([zone_field,
                               count_field,
                               sum_field,
-                              avg_field,
-                              prod_field])
+                              avg_field])
 
             # to show the overall progress, cycling through zones
             tot_zones = len(list(self.zonal_layer.getFeatures()))
@@ -568,7 +565,6 @@ class Svir:
                 fields.append(count_field)
                 fields.append(sum_field)
                 fields.append(avg_field)
-                fields.append(prod_field)
                 # Add fields to the new feature
                 feat.setFields(fields)
                 feat[self.zone_id_in_zones_attr_name] = zone_feature[
@@ -676,12 +672,10 @@ class Svir:
                     # update zonal stats
                     zone_stats[zone_id]['count'] += 1
                     zone_stats[zone_id]['sum'] += loss_value
-                    zone_stats[zone_id]['prod'] *= loss_value
                 else:
                     # initialize stats for the new zone found
                     zone_stats[zone_id] = {'count': 1,
-                                           'sum': loss_value,
-                                           'prod': loss_value}
+                                           'sum': loss_value}
         self.clear_progress_message_bar()
 
         msg = tr(
@@ -694,7 +688,6 @@ class Svir:
                                      DEBUG):
                 count_index = self.aggregation_layer.fieldNameIndex('count')
                 sum_index = self.aggregation_layer.fieldNameIndex('sum')
-                prod_index = self.aggregation_layer.fieldNameIndex('prod')
                 avg_index = self.aggregation_layer.fieldNameIndex('avg')
                 for current_zone, zone_feat in enumerate(
                         self.aggregation_layer.getFeatures()):
@@ -702,21 +695,19 @@ class Svir:
                     progress.setValue(progress_perc)
                     # get the id of the current zone
                     zone_id = zone_feat[self.zone_id_in_zones_attr_name]
-                    # initialize points_count, loss_sum, loss_prod and loss_avg
+                    # initialize points_count, loss_sum and loss_avg
                     # to zero, and update them afterwards only if the zone
                     # contains at least one loss point
                     points_count = 0
                     loss_sum = 0.0
-                    loss_prod = 0.0
                     loss_avg = 0.0
-                    # retrieve count, sum and prod from the dictionary, using
+                    # retrieve count and sum from the dictionary, using
                     # the zone id as key to get the values from the
                     # corresponding dict (otherwise, keep zero values)
                     if zone_id in zone_stats:
                         #points_count, loss_sum = zone_stats[zone_id]
                         points_count = zone_stats[zone_id]['count']
                         loss_sum = zone_stats[zone_id]['sum']
-                        loss_prod = zone_stats[zone_id]['prod']
                         # division by zero should be impossible, because we are
                         # computing this only for zones containing at least one
                         # point (otherwise we keep all zeros)
@@ -727,8 +718,6 @@ class Svir:
                         fid, count_index, int(points_count))
                     self.aggregation_layer.changeAttributeValue(
                         fid, sum_index, float(loss_sum))
-                    self.aggregation_layer.changeAttributeValue(
-                        fid, prod_index, float(loss_prod))
                     self.aggregation_layer.changeAttributeValue(
                         fid, avg_index, float(loss_avg))
         self.clear_progress_message_bar()
@@ -784,7 +773,6 @@ class Svir:
 
             count_index = self.aggregation_layer.fieldNameIndex('count')
             sum_index = self.aggregation_layer.fieldNameIndex('sum')
-            prod_index = self.aggregation_layer.fieldNameIndex('prod')
             avg_index = self.aggregation_layer.fieldNameIndex('avg')
 
             # We cycle through zones in the aggregation_layer, because the
@@ -800,7 +788,6 @@ class Svir:
                 with TraceTimeManager(msg, DEBUG):
                     points_count = 0
                     loss_sum = 0
-                    loss_prod = 0
                     loss_avg = 0
                     zone_geometry = zone_feature.geometry()
                     # Find ids of points within the bounding box of the zone
@@ -828,7 +815,6 @@ class Svir:
                                 no_loss_points_in_any_zone = False
                                 point_loss = point_feature[self.loss_attr_name]
                                 loss_sum += point_loss
-                                loss_prod *= point_loss
                     # if there's at least one point in the zone, update avg
                     if points_count > 0:
                         loss_avg = loss_sum / points_count
@@ -839,8 +825,6 @@ class Svir:
                             fid, count_index, points_count)
                         self.aggregation_layer.changeAttributeValue(
                             fid, sum_index, loss_sum)
-                        self.aggregation_layer.changeAttributeValue(
-                            fid, prod_index, loss_prod)
                         self.aggregation_layer.changeAttributeValue(
                             fid, avg_index, loss_avg)
         self.clear_progress_message_bar()


### PR DESCRIPTION
As also Chris agrees, it was useful to (recently) add the average loss for each zone, but contextually we also added the product of losses, which was actually pretty meaningless (a single point with zero losses would make the whole product zero). Therefore we are removing it.
