### PR TITLE
Mac settings fix

### DIFF
--- a/svir/settings_dialog.py
+++ b/svir/settings_dialog.py
@@ -18,7 +18,6 @@ class SettingsDialog(QtGui.QDialog, Ui_SettingsDialog):
         """
         mySettings = QtCore.QSettings()
         platform_username = mySettings.value('svir/platform_username', '')
-        platform_username = mySettings.value('svir/platform_username', '')
         platform_password = mySettings.value('svir/platform_password', '')
         platform_hostname = mySettings.value(
             'svir/platform_hostname', 'https://platform.openquake.org')


### PR DESCRIPTION
fix
File "/Users/cgburton/.qgis2/python/plugins/svir/settings_dialog.py", line 21, in restoreState
    mySettings.value('svir/platform_username', ''))
TypeError: QLineEdit.setText(QString): argument 1 has unexpected type 'QPyNullVariant'
