### PR TITLE
add logistic sigmoid transformation and corresponding test

### DIFF
--- a/svir/process_layer.py
+++ b/svir/process_layer.py
@@ -150,8 +150,9 @@ class ProcessLayer():
         algorithm = TRANSFORMATION_ALGS[algorithm_name]
 
         # transform the values in the dictionary with the chosen algorithm
+        invalid_input_values = None
         try:
-            transformed_dict = transform(
+            transformed_dict, invalid_input_values = transform(
                 initial_dict, algorithm, variant, inverse)
         except ValueError:
             raise
@@ -172,7 +173,7 @@ class ProcessLayer():
                 if type(value) not in (QPyNullVariant, NoneType):
                     value = float(value)
                 self.layer.changeAttributeValue(feat_id, new_attr_id, value)
-        return actual_new_attr_name
+        return actual_new_attr_name, invalid_input_values
 
     def find_attribute_id(self, attribute_name):
         """

--- a/svir/svir.py
+++ b/svir/svir.py
@@ -791,16 +791,24 @@ class Svir:
             new_attr_name = dlg.ui.new_field_name_txt.text()
             try:
                 with WaitCursorManager("Applying transformation", self.iface):
-                    res_attr_name = ProcessLayer(layer).transform_attribute(
-                        attribute_name, algorithm_name, variant,
-                        inverse, new_attr_name)
+                    res_attr_name, invalid_input_values = ProcessLayer(
+                        layer).transform_attribute(attribute_name,
+                                                   algorithm_name,
+                                                   variant,
+                                                   inverse,
+                                                   new_attr_name)
                 msg = ('The result of the transformation has been added to'
-                       'layer %s as a new attribute named %s') % (
+                       'layer %s as a new attribute named %s.') % (
                     layer.name(), res_attr_name)
+                if invalid_input_values:
+                    msg += (' The transformation could not '
+                            'be performed for the following '
+                            'input values: %s' % invalid_input_values)
                 self.iface.messageBar().pushMessage(
                     tr("Info"),
                     tr(msg),
-                    level=QgsMessageBar.INFO,
+                    level=(QgsMessageBar.INFO if not invalid_input_values
+                           else QgsMessageBar.WARNING),
                     duration=8)
             except (ValueError, NotImplementedError) as e:
                 self.iface.messageBar().pushMessage(

--- a/svir/test/test_transformations.py
+++ b/svir/test/test_transformations.py
@@ -66,52 +66,52 @@ class RankTestCase(unittest.TestCase):
         self.input_list = [2, 0, 2, 1, 2, 3, 2]
 
     def test_rank_direct_average(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="AVERAGE", inverse=False)
         self.assertEqual(rank_list, [4.5, 1, 4.5, 2, 4.5, 7, 4.5])
 
     def test_rank_direct_min(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="MIN", inverse=False)
         self.assertEqual(rank_list, [3, 1, 3, 2, 3, 7, 3])
 
     def test_rank_direct_max(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="MAX", inverse=False)
         self.assertEqual(rank_list, [6, 1, 6, 2, 6, 7, 6])
 
     def test_rank_direct_dense(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="DENSE", inverse=False)
         self.assertEqual(rank_list, [3, 1, 3, 2, 3, 4, 3])
 
     def test_rank_direct_ordinal(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="ORDINAL", inverse=False)
         self.assertEqual(rank_list, [3, 1, 4, 2, 5, 7, 6])
 
     def test_rank_inverse_average(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="AVERAGE", inverse=True)
         self.assertEqual(rank_list, [3.5, 7, 3.5, 6, 3.5, 1, 3.5])
 
     def test_rank_inverse_min(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="MIN", inverse=True)
         self.assertEqual(rank_list, [2, 7, 2, 6, 2, 1, 2])
 
     def test_rank_inverse_max(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="MAX", inverse=True)
         self.assertEqual(rank_list, [5, 7, 5, 6, 5, 1, 5])
 
     def test_rank_inverse_dense(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="DENSE", inverse=True)
         self.assertEqual(rank_list, [2, 4, 2, 3, 2, 1, 2])
 
     def test_rank_inverse_ordinal(self):
-        rank_list = self.alg(
+        rank_list, _ = self.alg(
             self.input_list, variant_name="ORDINAL", inverse=True)
         self.assertEqual(rank_list, [2, 7, 3, 6, 4, 1, 5])
 
@@ -123,7 +123,7 @@ class MinMaxTestCase(unittest.TestCase):
         self.input_list = [2, 0, 2, 1, 2, 3, 2]
 
     def test_min_max_direct(self):
-        min_max_list = self.alg(self.input_list, inverse=False)
+        min_max_list, _ = self.alg(self.input_list, inverse=False)
         self.assertEqual(min_max_list, [0.6666666666666666,
                                         0.0,
                                         0.6666666666666666,
@@ -133,7 +133,7 @@ class MinMaxTestCase(unittest.TestCase):
                                         0.6666666666666666])
 
     def test_min_max_inverse(self):
-        min_max_list = self.alg(self.input_list, inverse=True)
+        min_max_list, _ = self.alg(self.input_list, inverse=True)
         self.assertEqual(min_max_list, [0.33333333333333337,
                                         1.0,
                                         0.33333333333333337,
@@ -150,7 +150,7 @@ class ZScoreTestCase(unittest.TestCase):
         self.input_list = [2, 0, 2, 1, 2, 3, 2]
 
     def test_z_score_direct(self):
-        z_score_list = self.alg(self.input_list, inverse=False)
+        z_score_list, _ = self.alg(self.input_list, inverse=False)
         expected_list = [0.3244428422615252,
                          -1.9466570535691505,
                          0.3244428422615252,
@@ -162,7 +162,7 @@ class ZScoreTestCase(unittest.TestCase):
             self.assertAlmostEqual(z_score_list[i], expected_list[i], places=6)
 
     def test_z_score_inverse(self):
-        z_score_list = self.alg(self.input_list, inverse=True)
+        z_score_list, _ = self.alg(self.input_list, inverse=True)
         expected_list = [-4.2177569493998259,
                          -1.9466570535691505,
                          -4.2177569493998259,
@@ -185,7 +185,7 @@ class Log10TestCase(unittest.TestCase):
                       94062,
                       158661,
                       174568]
-        log10_list = self.alg(input_list)
+        log10_list, _ = self.alg(input_list)
         expected_list = [5.005391,
                          4.973507,
                          4.973414,
@@ -208,7 +208,7 @@ class Log10TestCase(unittest.TestCase):
                       94062,
                       158661,
                       174568]
-        log10_list = self.alg(
+        log10_list, _ = self.alg(
             input_list, variant_name='INCREMENT BY ONE IF ZEROS ARE FOUND')
         expected_list = [5.005391,
                          4.973507,
@@ -224,7 +224,7 @@ class Log10TestCase(unittest.TestCase):
                       0,
                       0,
                       174568]
-        log10_list = self.alg(
+        log10_list, _ = self.alg(
             input_list, variant_name='INCREMENT BY ONE IF ZEROS ARE FOUND')
         expected_list = [5.005395,
                          4.973511,
@@ -240,7 +240,7 @@ class Log10TestCase(unittest.TestCase):
                       0,
                       0,
                       174568]
-        log10_list = self.alg(
+        log10_list, _ = self.alg(
             input_list, variant_name='IGNORE ZEROS')
         expected_list = [5.005391,
                          4.973507,
@@ -262,7 +262,7 @@ class QuadraticTestCase(unittest.TestCase):
                            120813]
 
     def test_quadratic_direct_increasing(self):
-        quadratic_list = self.alg(
+        quadratic_list, _ = self.alg(
             self.input_list, variant_name="INCREASING", inverse=False)
         expected_list = [0.102969,
                          0.112452,
@@ -274,7 +274,7 @@ class QuadraticTestCase(unittest.TestCase):
                 quadratic_list[i], expected_list[i], places=4)
 
     def test_quadratic_direct_decreasing(self):
-        quadratic_list = self.alg(
+        quadratic_list, _ = self.alg(
             self.input_list, variant_name="DECREASING", inverse=False)
         expected_list = [0.461194,
                          0.441774,
@@ -286,7 +286,7 @@ class QuadraticTestCase(unittest.TestCase):
                 quadratic_list[i], expected_list[i], places=4)
 
     def test_quadratic_inverse_increasing(self):
-        quadratic_list = self.alg(
+        quadratic_list, _ = self.alg(
             self.input_list, variant_name="INCREASING", inverse=True)
         expected_list = [0.897032,
                          0.887548,
@@ -298,7 +298,7 @@ class QuadraticTestCase(unittest.TestCase):
                 quadratic_list[i], expected_list[i], places=4)
 
     def test_quadratic_inverse_decreasing(self):
-        quadratic_list = self.alg(
+        quadratic_list, _ = self.alg(
             self.input_list, variant_name="DECREASING", inverse=True)
         expected_list = [0.538806,
                          0.558266,
@@ -314,22 +314,56 @@ class SigmoidTestCase(unittest.TestCase):
 
     def setUp(self):
         self.alg = TRANSFORMATION_ALGS["SIGMOID"]
-        self.input_list = [-1,
-                           0,
-                           1,
-                           -0.3,
-                           0.3]
 
-    def test_sigmoid(self):
-        sigmoid_list = self.alg(self.input_list)
+    def test_sigmoid_direct(self):
+        input_list = [-1,
+                      0,
+                      1,
+                      -0.3,
+                      0.3]
+        sigmoid_list, _ = self.alg(input_list)
         expected_list = [0.268941421,
                          0.5,
                          0.7310585790,
                          0.425557483,
                          0.574442517]
-        for i in range(len(self.input_list)):
+        for i in range(len(input_list)):
             self.assertAlmostEqual(
                 sigmoid_list[i], expected_list[i], places=4)
+
+    def test_sigmoid_inverse(self):
+        input_list = [0.268941421,
+                      0.5,
+                      0.7310585790,
+                      0.425557483,
+                      0.574442517]
+        sigmoid_list, _ = self.alg(input_list, inverse=True)
+        expected_list = [-1,
+                         0,
+                         1,
+                         -0.3,
+                         0.3]
+        for i in range(len(input_list)):
+            self.assertAlmostEqual(
+                sigmoid_list[i], expected_list[i], places=4)
+
+    def test_sigmoid_inverse_zero_division(self):
+        input_list = [0.268941421,
+                      0.5,
+                      1,
+                      0.425557483,
+                      0.574442517]
+        sigmoid_list, invalid_input_values = self.alg(input_list, inverse=True)
+        expected_list = [-1,
+                         0,
+                         QPyNullVariant(float),
+                         -0.3,
+                         0.3]
+        self.assertEqual(invalid_input_values, [1])
+        for i in range(len(input_list)):
+            if expected_list[i] != QPyNullVariant(float):
+                self.assertAlmostEqual(
+                    sigmoid_list[i], expected_list[i], places=4)
 
 
 if __name__ == '__main__':

--- a/svir/transformation_algs.py
+++ b/svir/transformation_algs.py
@@ -26,7 +26,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 """
 import math
-from numpy import mean, std, argwhere, amax, amin, log10
+from numpy import mean, std, argwhere, amax, amin, log10, log
 from types import NoneType
 from qgis import QPyNullVariant
 from utils import Register
@@ -44,7 +44,7 @@ def transform(features_dict, algorithm, variant_name="", inverse=False):
     return a dict containing the transformed values with the original ids
     """
     # make a copy of the dictionary containing features (ids and values) and
-    # remove elements containing missing values, so the normalization is
+    # remove elements containing missing values, so the transformation is
     # performed only on the subset of valid values
     f_dict_copy = features_dict.copy()
     # elements with null value will be saved in another dict, so they can be
@@ -55,11 +55,12 @@ def transform(features_dict, algorithm, variant_name="", inverse=False):
             dict_of_null_values[key] = value
     for key in dict_of_null_values.keys():
         del f_dict_copy[key]
-    transformed_list = algorithm(f_dict_copy.values(), variant_name, inverse)
+    transformed_list, invalid_input_values = algorithm(
+        f_dict_copy.values(), variant_name, inverse)
     transformed_dict = dict(zip(f_dict_copy.keys(), transformed_list))
     # add to the transformed_dict the null elements that were removed
     transformed_dict.update(dict_of_null_values)
-    return transformed_dict
+    return transformed_dict, invalid_input_values
 
 
 @TRANSFORMATION_ALGS.add('RANK')
@@ -163,7 +164,7 @@ def rank(input_list, variant_name="AVERAGE", inverse=False):
             if variant_name != "ORDINAL":
                 curr_idx -= top_amount
             previous_ties += top_amount - 1
-    return rank_list
+    return rank_list, None
 
 
 @TRANSFORMATION_ALGS.add('Z_SCORE')
@@ -184,7 +185,7 @@ def z_score(input_list, variant_name=None, inverse=False):
         input_copy[:] = [-x for x in input_list]
     output_list = [
         1.0 * (num - mean_val) / stddev_val for num in input_copy]
-    return output_list
+    return output_list, None
 
 
 @TRANSFORMATION_ALGS.add('MIN_MAX')
@@ -209,7 +210,7 @@ def min_max(input_list, variant_name=None, inverse=False):
     else:
         output_list = map(
             lambda x: (x - list_min) / list_range, input_list)
-    return output_list
+    return output_list, None
 
 
 @TRANSFORMATION_ALGS.add('LOG10')
@@ -239,7 +240,7 @@ def log10_(input_list,
         if variant_name == 'INCREMENT BY ONE IF ZEROS ARE FOUND':
             corrected_input = [input_value + 1 for input_value in input_list]
             output_list = list(log10(corrected_input))
-            return output_list
+            return output_list, None
         elif variant_name == 'IGNORE ZEROS':
             output_list = []
             for input_value in input_list:
@@ -248,9 +249,9 @@ def log10_(input_list,
                     output_list.append(output_value)
                 else:
                     output_list.append(log10(input_value))
-            return output_list
+            return output_list, None
     output_list = list(log10(input_list))
-    return output_list
+    return output_list, None
 
 
 @TRANSFORMATION_ALGS.add('QUADRATIC')
@@ -283,7 +284,7 @@ def simple_quadratic(input_list, variant_name="INCREASING", inverse=False):
         raise NotImplementedError("%s variant not implemented" % variant_name)
     if inverse:
         output_list[:] = [1.0 - x for x in output_list]
-    return output_list
+    return output_list, None
 
 
 @TRANSFORMATION_ALGS.add('SIGMOID')
@@ -291,11 +292,28 @@ def sigmoid(input_list, variant_name="", inverse=False):
     """
     Logistic sigmoid function:
         f(x) = 1 / [1 + e^(-x)]
+
+    Inverse function:
+        f(y) =  ln[y / (1 - y)]
     """
     if variant_name:
         raise NotImplementedError("%s variant not implemented" % variant_name)
+    output_list = []
+    invalid_input_values = []
     if inverse:
-        raise NotImplementedError("Inverse function not implemented")
-    output_list = map(
-        lambda x: 1 / (1 + math.exp(-x)), input_list)
-    return output_list
+        for y in input_list:
+            try:
+                output = log(y / (1 - y))
+            except:
+                output = QPyNullVariant(float)
+                invalid_input_values.append(y)
+            output_list.append(output)
+    else:  # direct
+        for x in input_list:
+            try:
+                output = 1 / (1 + math.exp(-x))
+            except:
+                output = QPyNullVariant(float)
+                invalid_input_values.append(x)
+            output_list.append(output)
+    return output_list, invalid_input_values

--- a/svir/transformation_dialog.py
+++ b/svir/transformation_dialog.py
@@ -78,7 +78,7 @@ class TransformationDialog(QDialog):
         if self.ui.algorithm_cbx.currentText() in ['RANK', 'QUADRATIC']:
             self.reload_variant_cbx()
         self.ui.inverse_ckb.setDisabled(
-            self.ui.algorithm_cbx.currentText() in ['LOG10', 'SIGMOID'])
+            self.ui.algorithm_cbx.currentText() in ['LOG10'])
 
     @pyqtSlot()
     def on_calc_btn_clicked(self):
@@ -138,7 +138,7 @@ class TransformationDialog(QDialog):
         else:
             self.ui.variant_cbx.setDisabled(True)
         self.ui.inverse_ckb.setDisabled(
-            self.ui.algorithm_cbx.currentText() in ['LOG10', 'SIGMOID'])
+            self.ui.algorithm_cbx.currentText() in ['LOG10'])
 
     def update_default_fieldname(self):
         if (not self.attr_name_user_def


### PR DESCRIPTION
Address bug https://bugs.launchpad.net/oq-svir/+bug/1380978
Add logistic sigmoid function to the set of available attribute transformations, together with the corresponding test.
Add the inverse function as requested by the updated bug description.
Produce Null output values when unacceptable inputs are found, and display the list of invalid inputs to the user in the QGIS notification bar.
